### PR TITLE
Fixes for documentation

### DIFF
--- a/location/serializers.py
+++ b/location/serializers.py
@@ -6,15 +6,11 @@ from . import models
 
 
 class ProfileTypeSerializer(serializers.ModelSerializer):
-    id = serializers.ReadOnlyField()
-    organization_uuid = serializers.CharField(
-        required=False,
-        help_text='Any value sent will be ignored and will be just taken '
-                  'from JWT payload')
 
     class Meta:
         model = models.ProfileType
         fields = '__all__'
+        read_only_fields = ('id', 'organization_uuid', )
 
 
 class CountriesWithBlank(Countries):
@@ -25,16 +21,12 @@ class CountriesWithBlank(Countries):
 
 
 class SiteProfileSerializer(serializers.ModelSerializer):
-    uuid = serializers.ReadOnlyField()
-    organization_uuid = serializers.CharField(
-        required=False,
-        help_text='Any value sent will be ignored and will be just taken '
-                  'from JWT payload')
     country = CountryField(required=False, countries=CountriesWithBlank())
 
     class Meta:
         model = models.SiteProfile
         fields = '__all__'
+        read_only_fields = ('uuid', 'organization_uuid', )
 
     def validate_profiletype(self, value):
         if (self.initial_data['organization_uuid'] !=

--- a/location/tests/test_views.py
+++ b/location/tests/test_views.py
@@ -431,7 +431,7 @@ class SiteProfileListViewsTest(TestCase):
             name='somewhere',
             organization_uuid=self.organization_uuid,
             address_line1='Chausseestr. 1', city='Berlin', postcode='10116')
-        sp3 = mfactories.SiteProfile.create(
+        mfactories.SiteProfile.create(
             name='focus focus focus',
             organization_uuid=self.organization_uuid,
             address_line1='Milkstr. 1', city='Galaxis', postcode='10101')
@@ -441,8 +441,8 @@ class SiteProfileListViewsTest(TestCase):
         response = view(request)
         self.assertEqual(len(response.data['results']), 2)
         results = [sp['uuid'] for sp in response.data['results']]
-        self.assertIn(sp1.uuid, results)
-        self.assertIn(sp2.uuid, results)
+        self.assertIn(str(sp1.uuid), results)
+        self.assertIn(str(sp2.uuid), results)
         request = self.factory.get('?search=Merlin')
         request.session = self.session
         view = SiteProfileViewSet.as_view({'get': 'list'})

--- a/location/views.py
+++ b/location/views.py
@@ -1,8 +1,9 @@
 from django.http import HttpRequest
 from django_filters import rest_framework as django_filters
-from rest_framework import viewsets
+from rest_framework import viewsets, status
 from rest_framework import filters as drf_filters
 from rest_framework.request import Request
+from rest_framework.response import Response
 
 from .models import ProfileType, SiteProfile
 from .permissions import OrganizationPermission
@@ -31,7 +32,11 @@ class ProfileTypeViewSet(viewsets.ModelViewSet):
 
     def create(self, request, *args, **kwargs):
         request_extended = self._extend_request(request)
-        return super().create(request_extended, *args, **kwargs)
+        serializer = self.get_serializer(data=request_extended.data)
+        serializer.is_valid(raise_exception=True)
+        organization_uuid = request.session['jwt_organization_uuid']
+        serializer.save(organization_uuid=organization_uuid)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def update(self, request, *args, **kwargs):
         request_extended = self._extend_request(request)
@@ -69,7 +74,11 @@ class SiteProfileViewSet(viewsets.ModelViewSet):
 
     def create(self, request, *args, **kwargs):
         request_extended = self._extend_request(request)
-        return super().create(request_extended, *args, **kwargs)
+        serializer = self.get_serializer(data=request_extended.data)
+        serializer.is_valid(raise_exception=True)
+        organization_uuid = request.session['jwt_organization_uuid']
+        serializer.save(organization_uuid=organization_uuid)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def update(self, request, *args, **kwargs):
         request_extended = self._extend_request(request)

--- a/location_service/settings/base.py
+++ b/location_service/settings/base.py
@@ -42,12 +42,14 @@ INSTALLED_APPS_DJANGO = [
 INSTALLED_APPS_THIRD_PARTIES = [
     'django_countries',
     'django_filters',
-    'drf_yasg',
     'rest_framework',
 
     # Health check
     'health_check',
     'health_check.db',
+
+    # Swagger/OpenAPI
+    'drf_yasg',
 ]
 
 INSTALLED_APPS_LOCAL = [

--- a/location_service/tests/test_urls.py
+++ b/location_service/tests/test_urls.py
@@ -19,9 +19,7 @@ class ProfileTypeOptionsViewsTest(TestCase):
         # reverse() would be better
         response = self.client.get('/docs/swagger.json')
         self.assertEqual(response.status_code, 200)
-        self.assertIn(
-            b'"info": {"title": "Location Service API", "version": "latest"}',
-            response.content)
+        self.assertIn('Location Service', str(response.content))
 
         # reverse() would be better
         response = self.client.get('/docs/swagger.yaml')

--- a/location_service/urls.py
+++ b/location_service/urls.py
@@ -1,28 +1,31 @@
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import path, re_path, include
+from rest_framework import permissions
+
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
-from rest_framework import permissions
 
 from location.routers import router
 
+swagger_info = openapi.Info(
+    title='Location Service API',
+    default_version='latest',
+    description="The location service enables your application to store and group international addresses.",
+)
+
 schema_view = get_schema_view(
-    openapi.Info(
-        title='Location Service API',
-        default_version='latest',
-    ),
+    swagger_info,
     public=True,
     permission_classes=(permissions.AllowAny,),
 )
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    re_path(r'^docs/swagger(?P<format>\.json|\.yaml)$',
+            schema_view.without_ui(cache_timeout=0), name='docs-swagger-raw'),
     path('docs/', schema_view.with_ui('swagger', cache_timeout=0),
          name='docs-swagger-ui'),
-    re_path(r'^docs/swagger(?P<format>\.json|\.yaml)$',
-            schema_view.without_ui(cache_timeout=0),
-            name='docs-swagger-raw'),
     path('health_check/', include('health_check.urls')),
     path('', include((router.urls, 'app_name'), namespace='location')),
 ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,8 @@
-Django==2.1.3
-django-countries>5.3<5.4
-django-filter>2.0<2.1
+Django~=2.1.6
+django-countries~=5.3.3
+django-filter~=2.1.0
 django-health-check==3.6.1
-drf-yasg>1.11<1.12
+drf-yasg~=1.11.0
 git+https://github.com/Humanitec/django-oauth-toolkit-jwt@v0.5.2#egg=django-oauth-toolkit-jwt
-djangorestframework>3.9<3.10
+djangorestframework~=3.9.2
 psycopg2-binary==2.7.5


### PR DESCRIPTION
- For the swagger Inspector to read the `help_texts` from the model fields, the swagger field overwriting had to be removed.
- When calling the swagger UI docs page in the browser an error occurred, because of the lack of `organization_uuid`, which was needed for extrapolating the queryset in the views.
- The requirements were updated higher than expected, so I rewrote them. Also, the Django security vulnerabilities should be fixed with this update.
- The description of the swagger should be like in the README.md.