### PR TITLE
Add organization_uuid to serializers allowed but ignored fields

### DIFF
--- a/location/serializers.py
+++ b/location/serializers.py
@@ -22,11 +22,16 @@ class CountriesWithBlank(Countries):
 
 class SiteProfileSerializer(serializers.ModelSerializer):
     country = CountryField(required=False, countries=CountriesWithBlank())
+    organization_uuid = serializers.CharField(  # ToDo: remove organization_uuid when FE has removed it from POST
+        required=False,
+        help_text='Any value sent will be ignored and will be just taken '
+                  'from JWT payload')
 
     class Meta:
         model = models.SiteProfile
         fields = '__all__'
-        read_only_fields = ('uuid', 'organization_uuid', )
+        read_only_fields = ('uuid', )  # ToDo: add 'organization_uuid', for documentation
+        # back when FE has removed it from POST
 
     def validate_profiletype(self, value):
         if (self.initial_data['organization_uuid'] !=


### PR DESCRIPTION
This hotfix should be reverted when the FE has updated its POST
requests.