### PR TITLE
Remove build-docker-static-image-tag and prebuild-docker-static-image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,31 +40,6 @@ pipeline:
       event: [tag]
       status: [success]
 
-  prebuild-docker-static-image:
-    image: python:3.6
-    commands:
-      - bash scripts/run-collectstatic.sh
-    when:
-      event: [tag]
-      status: [success]
-
-  build-docker-static-image-tag:
-    image: plugins/docker
-    insecure: true
-    registry:
-      from_secret: DOCKER_REGISTRY
-    repo:
-      from_secret: DOCKER_REPO_STATIC
-    dockerfile: Dockerfile.nginx
-    auto_tag: true
-    username:
-      from_secret: DOCKER_USERNAME
-    password:
-      from_secret: DOCKER_PASSWORD
-    when:
-      event: [tag]
-      status: [success]
-
   deploy-docs:
     image: python:3.6
     commands:


### PR DESCRIPTION
The building of the docker static image is not needed anymore and
creates errors in the new drone:
Error parsing reference: ":0.0" is not a valid repository/tag: invalid reference format
time="2019-06-04T13:12:30Z" level=fatal msg="exit status 1"