### PR TITLE
WAL-577: fix migration

### DIFF
--- a/location/migrations/0008_auto_20190605_0939.py
+++ b/location/migrations/0008_auto_20190605_0939.py
@@ -12,6 +12,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL("DROP INDEX IF EXISTS location_si_workflo_768d25_gin"),
         migrations.AlterField(
             model_name='siteprofile',
             name='workflowlevel2_uuid',


### PR DESCRIPTION
## Purpose

After PR https://github.com/Humanitec/location_service/pull/44 migration on existing database is failed, because somehow (?) index was created there.

## Approach
Fix last migration - remove index if it exists.