### PR TITLE
Assert organization_uuid from request.session is valid

### DIFF
--- a/location/tests/test_views.py
+++ b/location/tests/test_views.py
@@ -1,8 +1,10 @@
+import json
 from decimal import Decimal
 import uuid
 
 from django.test import TestCase
 from django.urls import reverse
+from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIRequestFactory
 
 from . import model_factories as mfactories
@@ -38,6 +40,17 @@ class ProfileTypeListViewsTest(TestCase):
         self.assertEqual(len(response.data['results']), 0)
         self.assertIsNone(response.data['next'])
         self.assertIsNone(response.data['previous'])
+
+    def test_valid_organization_uuid_in_session_fail(self):
+        request = self.factory.get('')
+        request.session = {
+            'jwt_organization_uuid': 'invalid_uuid',
+        }
+        view = ProfileTypeViewSet.as_view({'get': 'list'})
+        response = view(request).render()
+        self.assertIn("organization_uuid", json.loads(response.content)[0])
+        self.assertIn( "invalid_uuid", json.loads(response.content)[0])
+        self.assertEqual(response.status_code, 400)
 
     def test_list_ordering_default(self):
         for name in ('C', 'A', 'B'):

--- a/location/views.py
+++ b/location/views.py
@@ -1,7 +1,10 @@
+import re
+
 from django.http import HttpRequest
 from django_filters import rest_framework as django_filters
 from rest_framework import viewsets, status
 from rest_framework import filters as drf_filters
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -16,11 +19,22 @@ class OrganizationQuerySetMixin(object):
     Adds functionality to return a queryset filtered by the organization_uuid in the JWT header.
     If no jwt header is given, an empty queryset will be returned.
     """
+
+    @staticmethod
+    def _valid_uuid4(uuid_string):
+        uuid4hex = re.compile('^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}\Z', re.I)
+        match = uuid4hex.match(uuid_string)
+        return bool(match)
+
     def get_queryset(self):
         queryset = super().get_queryset()
         organization_uuid = self.request.session.get('jwt_organization_uuid', None)
         if not organization_uuid:
             return queryset.none()
+        if not self._valid_uuid4(organization_uuid):
+            raise ValidationError(
+                f'organization_uuid from JWT Token "{organization_uuid}" is not a valid UUID.'
+            )
         return queryset.filter(organization_uuid=organization_uuid)
 
 


### PR DESCRIPTION
To prevent unprecise ValidationErrors on filtering on UUID-Fields with invalid
values.